### PR TITLE
Update manifest.json

### DIFF
--- a/custom_components/viomi_vacuum_v8/manifest.json
+++ b/custom_components/viomi_vacuum_v8/manifest.json
@@ -1,6 +1,7 @@
 {
   "domain": "viomi_vacuum_v8",
   "name": "Viomi Vacuum V8",
+  "version": "1.0.0",
   "documentation": "https://github.com/tykarol/home-assistant-viomi-vacuum-v8",
   "requirements": [
     "construct==2.10.59",


### PR DESCRIPTION
https://developers.home-assistant.io/blog/2021/01/29/custom-integration-changes/#versions

The version key is required from Home Assistant version 2021.6